### PR TITLE
修复编译问题

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ LD = ld
 ASM = nasm
 
 C_FLAGS = -std=c99 -c -m32 -Wall -Wextra -ggdb -gstabs+ -ffreestanding \
-                 -I. -Iinclude -Iarch/i386 -Iarch/i386/include
-LD_FLAGS = -T scripts/kernel.ld -nostdlib
+                 -I. -Iinclude -Iarch/i386 -Iarch/i386/include -fno-stack-protector
+LD_FLAGS = -T scripts/kernel.ld -nostdlib -m elf_i386
 ASM_FLAGS = -f elf -g -F stabs
 
 all: $(S_OBJECTS) $(C_OBJECTS) link update_fd

--- a/driver/block_dev.c
+++ b/driver/block_dev.c
@@ -19,6 +19,7 @@
 #include <debug.h>
 #include <lib/string.h>
 #include <block_dev.h>
+#include <mbr.h>
 
 // 全局块设备链表
 block_dev_t *block_devs;

--- a/fs/mbr.c
+++ b/fs/mbr.c
@@ -17,6 +17,7 @@
  */
 
 #include <mbr.h>
+#include <debug.h>
 
  // MBR信息
 mbr_info_t mbr_info;

--- a/fs/sfs/sfs.c
+++ b/fs/sfs/sfs.c
@@ -83,7 +83,7 @@ static uint32_t sfs_alloc_block(void);
 static void sfs_free_block(uint32_t block_no);
 
 // 读取 inode
-static struct sfs_inode *sfs_read_inode(uint32_t inode_no);
+// static struct sfs_inode *sfs_read_inode(uint32_t inode_no);
 
 // 获取 inode 数据指针(从 inode_cache 获取，可能阻塞于磁盘IO)
 static uint8_t *sfs_read_inode(uint32_t inode_no);


### PR DESCRIPTION
在 arch 上编译出现以下错误
`fs/sfs/sfs.c:89:17: 错误：与‘sfs_read_inode’类型冲突
 static uint8_t *sfs_read_inode(uint32_t inode_no);`
`fs/mbr.c:44:9: 警告：隐式声明函数‘cprintk’ [-Wimplicit-function-declaration]`
`ld: i386 architecture of input file ./arch/i386/task/switch_to.o' is incompatible with i386:x86-64 output`
`Hurlex-II/arch/i386/task/task.c:102: undefined reference to __stack_chk_fail_local'`
