### PR TITLE
修复了物理内存管理模块的bug

### DIFF
--- a/arch/i386/mm/pmm.c
+++ b/arch/i386/mm/pmm.c
@@ -88,7 +88,7 @@ static void phy_pages_init(e820map_t *e820map)
                         phy_mem_length = ZONE_HIGHMEM_ADDR;
                         break;
                 }
-                phy_mem_length = e820map->map[i].length_low;
+                phy_mem_length += e820map->map[i].length_low;
         }
 
         uint32_t pages_mem_length = sizeof(page_t) * (phy_mem_length / PMM_PAGE_SIZE);

--- a/mm/buddy_mm.c
+++ b/mm/buddy_mm.c
@@ -227,7 +227,7 @@ static void buddy_free_pages(uint32_t addr, uint32_t n)
 
         uint32_t order = 0, order_size = 1;
         while (n >= order_size) {
-                if (n & order_size) != 0) {
+                if (（n & order_size) != 0) {
                         buddy_free_pages_sub(base, order);
                         base += order_size;
                         n -= order_size;

--- a/mm/buddy_mm.c
+++ b/mm/buddy_mm.c
@@ -222,10 +222,12 @@ static void buddy_free_pages(uint32_t addr, uint32_t n)
         }
 
         page_t *base = addr_to_page(addr);
+        
+        atomic_add(&buddy_mm_info.phy_page_now_count, n);
 
         uint32_t order = 0, order_size = 1;
         while (n >= order_size) {
-                if ((page_to_idx(base) & order_size) != 0) {
+                if (n & order_size) != 0) {
                         buddy_free_pages_sub(base, order);
                         base += order_size;
                         n -= order_size;
@@ -233,17 +235,6 @@ static void buddy_free_pages(uint32_t addr, uint32_t n)
                 order++;
                 order_size <<= 1;
         }
-        while (n != 0) {
-                while (n < order_size) {
-                        order--;
-                        order_size >>= 1;
-                }
-                buddy_free_pages_sub(base, order);
-                base += order_size;
-                n -= order_size;
-        }
-
-        atomic_add(&buddy_mm_info.phy_page_now_count, n);
 }
 
 static uint32_t buddy_free_pages_count(void)


### PR DESCRIPTION
**bug1:**
arch/i386/mm/pmm.c中91行代码，在总物理内存小于`ZONE_HIGHMEM_ADDR`时计算得到的`phy_mem_length`仅等于最后一段不可用内存的长度。另：100-113行感觉内存分布的情况没有完整考虑进来，但出bug应该也是很极端的情况，所以没有细究。
**bug2：**
mm/buddy_mm.c中，`buddy_free_pages()`函数246行应该放到所有循环之前（n值被循环改变了），以及，考虑到任意一个数可以由不重复的2的n次幂累加得到，所以只需把循环1的条件判断稍作修改即可完成内存的分割（初看前辈代码时以为前辈就是这个思路，但仔细往下看的时候反而不太理解前辈在这段代码中用多次循环的意图了）。
对操作系统相关还在摸索阶段，可能对前辈源码理解有误，望见谅。